### PR TITLE
Add search suggestions, newsletter CTA, and expanded footer

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,19 +1,29 @@
-<!doctype html><html lang="ja"><head>
-<meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
 <title>404 | げーけい部！</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Orbitron:wght@600;800&family=Press+Start+2P&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="./styles.css"></head>
+<link rel="stylesheet" href="./styles.css">
+</head>
 <body>
-<header class="site-header"><div class="inner">
-  <div class="brand">げーけい部！</div>
-  <nav class="nav">
-    <a href="./index.html">Home</a>
-    <a href="./projects.html">Projects</a>
-    <a href="./about.html">About</a>
-  </nav>
-</div></header>
+<header class="site-header">
+  <div class="inner">
+    <div class="brand">げーけい部！</div>
+    <nav class="nav">
+      <a href="./index.html">Home</a>
+      <a href="./projects.html">Projects</a>
+      <a href="./about.html">About</a>
+    </nav>
+    <div class="search-bar">
+      <input type="text" id="search-input" placeholder="タグ・人物・用語を検索">
+      <ul id="suggestions" class="suggestions"></ul>
+    </div>
+  </div>
+</header>
 <main class="container">
   <section class="card hero">
     <span class="badge">404</span>
@@ -21,4 +31,36 @@
     <p><a class="btn" href="./index.html">トップへ戻る</a></p>
   </section>
 </main>
-</body></html>
+<footer class="site-footer">
+  <div class="container footer-content">
+    <div class="footer-col">
+      <h3>サイトマップ</h3>
+      <ul>
+        <li><a href="./index.html">Home</a></li>
+        <li><a href="./projects.html">Projects</a></li>
+        <li><a href="./about.html">About</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h3>用語集 & ポリシー</h3>
+      <ul>
+        <li><a href="./glossary.html">用語集</a></li>
+        <li><a href="./policy.html">運営ポリシー</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h3>連絡先</h3>
+      <ul>
+        <li><a href="mailto:info@example.com">info@example.com</a></li>
+        <li><a href="https://x.com" target="_blank" rel="noopener">X</a></li>
+        <li><a href="https://github.com" target="_blank" rel="noopener">GitHub</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="container copyright">
+    <small>© <span id="year"></span> げーけい部！</small>
+  </div>
+</footer>
+<script src="./script.js"></script>
+</body>
+</html>

--- a/glossary.html
+++ b/glossary.html
@@ -3,8 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>About | げーけい部！</title>
-<meta name="description" content="げーけい部！について。ゲーム×経済学の学び場。">
+<title>用語集 | げーけい部！</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Orbitron:wght@600;800&family=Press+Start+2P&display=swap" rel="stylesheet">
@@ -25,24 +24,13 @@
     </div>
   </div>
 </header>
-
 <main class="container">
-<section class="hero card reveal">
-    <span class="badge">ABOUT</span>
-    <h1>ゲームで経済を“体感的”に学ぶ場。</h1>
-    <p>「げーけい部！」は、ゲームのメカニクスやコミュニティから経済の考え方を学ぶメディアです。むずかしい数式は最小限に抑え、図解と比喩で直感的に理解できます。</p>
-  </section>
-
-<section class="card reveal" style="margin-top:20px">
-    <h2>やっていくこと</h2>
-    <ul>
-      <li>ゲーム事例 × 経済用語の図解</li>
-      <li>読みやすい短編コラム</li>
-      <li>学習に役立つシンプルなツールの配布</li>
-    </ul>
+  <section class="card hero">
+    <span class="badge">GLOSSARY</span>
+    <h1>用語集</h1>
+    <p>準備中です。</p>
   </section>
 </main>
-
 <footer class="site-footer">
   <div class="container footer-content">
     <div class="footer-col">
@@ -76,4 +64,3 @@
 <script src="./script.js"></script>
 </body>
 </html>
-

--- a/home.html
+++ b/home.html
@@ -12,14 +12,18 @@
   </head>
   <body>
     <header class="site-header">
-      <nav class="container">
-        <a class="brand" href="/">OurOrg</a>
-        <ul class="nav">
-          <li><a aria-current="page" href="home.html">Home</a></li>
-          <li><a href="about.html">About</a></li>
-          <li><a href="projects.html">Projects</a></li>
-        </ul>
-      </nav>
+      <div class="inner">
+        <div class="brand">げーけい部！</div>
+        <nav class="nav">
+          <a href="./index.html">Home</a>
+          <a href="./projects.html">Projects</a>
+          <a href="./about.html">About</a>
+        </nav>
+        <div class="search-bar">
+          <input type="text" id="search-input" placeholder="タグ・人物・用語を検索">
+          <ul id="suggestions" class="suggestions"></ul>
+        </div>
+      </div>
     </header>
 
     <main class="container">
@@ -32,8 +36,33 @@
     </main>
 
     <footer class="site-footer">
-      <div class="container">
-        <small>&copy; <span id="year"></span> OurOrg</small>
+      <div class="container footer-content">
+        <div class="footer-col">
+          <h3>サイトマップ</h3>
+          <ul>
+            <li><a href="./index.html">Home</a></li>
+            <li><a href="./projects.html">Projects</a></li>
+            <li><a href="./about.html">About</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3>用語集 & ポリシー</h3>
+          <ul>
+            <li><a href="./glossary.html">用語集</a></li>
+            <li><a href="./policy.html">運営ポリシー</a></li>
+          </ul>
+        </div>
+        <div class="footer-col">
+          <h3>連絡先</h3>
+          <ul>
+            <li><a href="mailto:info@example.com">info@example.com</a></li>
+            <li><a href="https://x.com" target="_blank" rel="noopener">X</a></li>
+            <li><a href="https://github.com" target="_blank" rel="noopener">GitHub</a></li>
+          </ul>
+        </div>
+      </div>
+      <div class="container copyright">
+        <small>© <span id="year"></span> げーけい部！</small>
       </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -23,6 +23,10 @@
       <a href="./projects.html">Projects</a>
       <a href="./about.html">About</a>
     </nav>
+    <div class="search-bar">
+      <input type="text" id="search-input" placeholder="タグ・人物・用語を検索">
+      <ul id="suggestions" class="suggestions"></ul>
+    </div>
   </div>
 </header>
 
@@ -36,14 +40,77 @@
     </div>
   </section>
 
+  <section class="newsletter card reveal">
+    <h2>週1で“ゲーム×経済学”の新ネタと図解</h2>
+    <p>最新コンテンツをメールで受け取り、サンプルPDFもチェックできます。</p>
+    <form class="newsletter-form">
+      <input type="email" placeholder="メールアドレス" required>
+      <button type="submit" class="btn">登録する</button>
+    </form>
+    <div class="pdf-preview-wrapper">
+      <iframe src="sample-newsletter.pdf" class="pdf-preview"></iframe>
+    </div>
+  </section>
+
 <section class="card reveal" style="margin-top:20px">
     <h2>最新トピック</h2>
     <p>最新の記事やお知らせを3つほど掲載する予定です。</p>
   </section>
+
+  <section class="social-proof card reveal" style="margin-top:20px">
+    <h2>みんなに読まれています</h2>
+    <ul class="proof-list">
+      <li><strong>1,200+</strong> 名の購読者</li>
+      <li><strong>300+</strong> 件のXでの言及</li>
+      <li><strong>5</strong> 社のメディア掲載</li>
+    </ul>
+  </section>
 </main>
 
-<footer class="container" style="opacity:.7;padding-bottom:56px">
-  <small>© 2025 げーけい部！</small>
+<div id="exit-modal" class="modal">
+  <div class="modal-content">
+    <button id="modal-close">&times;</button>
+    <h2>週1で“ゲーム×経済学”の新ネタと図解</h2>
+    <p>ニュースレターに登録してサンプルPDFをチェック！</p>
+    <form class="newsletter-form">
+      <input type="email" placeholder="メールアドレス" required>
+      <button type="submit" class="btn">登録する</button>
+    </form>
+    <div class="pdf-preview-wrapper">
+      <iframe src="sample-newsletter.pdf" class="pdf-preview"></iframe>
+    </div>
+  </div>
+</div>
+
+<footer class="site-footer">
+  <div class="container footer-content">
+    <div class="footer-col">
+      <h3>サイトマップ</h3>
+      <ul>
+        <li><a href="./index.html">Home</a></li>
+        <li><a href="./projects.html">Projects</a></li>
+        <li><a href="./about.html">About</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h3>用語集 & ポリシー</h3>
+      <ul>
+        <li><a href="./glossary.html">用語集</a></li>
+        <li><a href="./policy.html">運営ポリシー</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h3>連絡先</h3>
+      <ul>
+        <li><a href="mailto:info@example.com">info@example.com</a></li>
+        <li><a href="https://x.com" target="_blank" rel="noopener">X</a></li>
+        <li><a href="https://github.com" target="_blank" rel="noopener">GitHub</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="container copyright">
+    <small>© <span id="year"></span> げーけい部！</small>
+  </div>
 </footer>
 <script src="./script.js"></script>
 </body>

--- a/policy.html
+++ b/policy.html
@@ -3,8 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<title>About | げーけい部！</title>
-<meta name="description" content="げーけい部！について。ゲーム×経済学の学び場。">
+<title>運営ポリシー | げーけい部！</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&family=Orbitron:wght@600;800&family=Press+Start+2P&display=swap" rel="stylesheet">
@@ -25,24 +24,13 @@
     </div>
   </div>
 </header>
-
 <main class="container">
-<section class="hero card reveal">
-    <span class="badge">ABOUT</span>
-    <h1>ゲームで経済を“体感的”に学ぶ場。</h1>
-    <p>「げーけい部！」は、ゲームのメカニクスやコミュニティから経済の考え方を学ぶメディアです。むずかしい数式は最小限に抑え、図解と比喩で直感的に理解できます。</p>
-  </section>
-
-<section class="card reveal" style="margin-top:20px">
-    <h2>やっていくこと</h2>
-    <ul>
-      <li>ゲーム事例 × 経済用語の図解</li>
-      <li>読みやすい短編コラム</li>
-      <li>学習に役立つシンプルなツールの配布</li>
-    </ul>
+  <section class="card hero">
+    <span class="badge">POLICY</span>
+    <h1>運営ポリシー</h1>
+    <p>準備中です。</p>
   </section>
 </main>
-
 <footer class="site-footer">
   <div class="container footer-content">
     <div class="footer-col">
@@ -76,4 +64,3 @@
 <script src="./script.js"></script>
 </body>
 </html>
-

--- a/projects.html
+++ b/projects.html
@@ -19,6 +19,10 @@
       <a href="./projects.html">Projects</a>
       <a href="./about.html">About</a>
     </nav>
+    <div class="search-bar">
+      <input type="text" id="search-input" placeholder="タグ・人物・用語を検索">
+      <ul id="suggestions" class="suggestions"></ul>
+    </div>
   </div>
 </header>
 
@@ -56,8 +60,35 @@
   </section>
 </main>
 
-<footer class="container" style="opacity:.7;padding-bottom:56px">
-  <small>© 2025 げーけい部！</small>
+<footer class="site-footer">
+  <div class="container footer-content">
+    <div class="footer-col">
+      <h3>サイトマップ</h3>
+      <ul>
+        <li><a href="./index.html">Home</a></li>
+        <li><a href="./projects.html">Projects</a></li>
+        <li><a href="./about.html">About</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h3>用語集 & ポリシー</h3>
+      <ul>
+        <li><a href="./glossary.html">用語集</a></li>
+        <li><a href="./policy.html">運営ポリシー</a></li>
+      </ul>
+    </div>
+    <div class="footer-col">
+      <h3>連絡先</h3>
+      <ul>
+        <li><a href="mailto:info@example.com">info@example.com</a></li>
+        <li><a href="https://x.com" target="_blank" rel="noopener">X</a></li>
+        <li><a href="https://github.com" target="_blank" rel="noopener">GitHub</a></li>
+      </ul>
+    </div>
+  </div>
+  <div class="container copyright">
+    <small>© <span id="year"></span> げーけい部！</small>
+  </div>
 </footer>
 <script src="./script.js"></script>
 </body>

--- a/sample-newsletter.pdf
+++ b/sample-newsletter.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 100 700 Td (Sample Newsletter) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000056 00000 n 
+0000000105 00000 n 
+0000000200 00000 n 
+0000000271 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+344
+%%EOF

--- a/script.js
+++ b/script.js
@@ -21,3 +21,40 @@ document.getElementById('year').textContent = new Date().getFullYear();
 
   targets.forEach(el => io.observe(el));
 })();
+
+// 検索バーの先読みサジェスト
+const keywords = ['囚人のジレンマ','価格弾力性','ナッシュ均衡','ゲーム理論','限界費用','期待効用'];
+const searchBar = document.querySelector('.search-bar');
+if(searchBar){
+  const input = searchBar.querySelector('#search-input');
+  const list = searchBar.querySelector('#suggestions');
+  input.addEventListener('input', () => {
+    const q = input.value.trim();
+    if(!q){ list.innerHTML=''; searchBar.classList.remove('open'); return; }
+    const matches = keywords.filter(k => k.includes(q));
+    list.innerHTML = matches.map(m => `<li>${m}</li>`).join('');
+    searchBar.classList.toggle('open', matches.length>0);
+  });
+  list.addEventListener('click', e => {
+    if(e.target.tagName === 'LI'){
+      input.value = e.target.textContent;
+      list.innerHTML='';
+      searchBar.classList.remove('open');
+    }
+  });
+}
+
+// 離脱時モーダル表示
+const exitModal = document.getElementById('exit-modal');
+let modalShown = false;
+if(exitModal){
+  document.addEventListener('mouseleave', e => {
+    if(e.clientY <= 0 && !modalShown){
+      exitModal.classList.add('show');
+      modalShown = true;
+    }
+  });
+  document.getElementById('modal-close').addEventListener('click', () => {
+    exitModal.classList.remove('show');
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -10,6 +10,12 @@ a:hover{color:#0D0F1A;background:var(--neon-magenta);box-shadow:0 0 12px var(--n
 .site-header .inner{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:12px 24px}
 .brand{font-weight:800;font-size:20px;color:var(--neon-magenta);text-shadow:0 0 8px rgba(255,46,255,.8)}
 .nav{display:flex;gap:16px}
+.search-bar{position:relative}
+.search-bar input{padding:6px 8px;border-radius:var(--radius);border:1px solid var(--neon-cyan);background:#151926;color:#E8EEFF;min-width:180px}
+.suggestions{list-style:none;margin:0;padding:0;position:absolute;top:100%;left:0;right:0;background:#151926;border:1px solid rgba(255,255,255,.1);border-top:none;max-height:160px;overflow-y:auto;display:none;z-index:20}
+.suggestions li{padding:6px 8px;cursor:pointer}
+.suggestions li:hover{background:rgba(255,255,255,.1)}
+.search-bar.open .suggestions{display:block}
 .btn{display:inline-block;padding:10px 16px;border-radius:14px;border:1px solid var(--neon-cyan)}
 .btn:hover{transform:translateY(-1px);box-shadow:0 0 14px rgba(0,229,255,.8)}
 .hero{padding:56px 24px 64px;background:linear-gradient(180deg,rgba(154,0,255,.18),transparent 60%)}
@@ -78,6 +84,29 @@ a:hover{color:#0D0F1A;background:var(--neon-magenta);box-shadow:0 0 12px var(--n
 .grid.is-visible .article-card:nth-child(7){ transition-delay:.35s }
 .grid.is-visible .article-card:nth-child(8){ transition-delay:.40s }
 .grid.is-visible .article-card:nth-child(9){ transition-delay:.45s }
+
+/* Newsletter CTA */
+.newsletter-form{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}
+.newsletter-form input{flex:1;padding:8px;border-radius:var(--radius);border:1px solid var(--neon-cyan);background:#151926;color:#E8EEFF}
+.pdf-preview-wrapper{margin-top:16px}
+.pdf-preview{width:100%;height:200px;border:1px solid rgba(255,255,255,.1)}
+
+/* Social proof */
+.proof-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
+
+/* Modal */
+.modal{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;padding:24px;z-index:100}
+.modal.show{display:flex}
+.modal-content{background:#151926;border-radius:var(--radius);padding:24px;max-width:500px;width:100%;position:relative}
+#modal-close{position:absolute;top:8px;right:12px;background:none;border:none;font-size:24px;color:#E8EEFF;cursor:pointer}
+
+/* Footer */
+.site-footer{background:#151926;margin-top:40px}
+.footer-content{display:flex;flex-wrap:wrap;gap:24px;justify-content:space-between;padding:24px 0}
+.footer-col h3{margin-top:0}
+.footer-col ul{list-style:none;margin:0;padding:0}
+.footer-col li{margin-bottom:4px}
+.copyright{text-align:center;padding:12px 0;border-top:1px solid rgba(255,255,255,.06)}
 
 /* === ユーザーが「動きを減らす」を設定していたらオフ === */
 @media (prefers-reduced-motion: reduce){


### PR DESCRIPTION
## Summary
- Add search bar with typeahead suggestions for economics terms
- Introduce newsletter CTA with sample PDF preview and exit intent modal
- Showcase social proof metrics and expand footer with sitemap, glossary, policy and contacts

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dedcd603883339dfdb5bd7d856e54