### PR TITLE
feat: add neon hero and topic filter

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,19 +26,74 @@
   </div>
 </header>
 
-<main class="container">
-<section class="hero card reveal">
-    <span class="badge">GAME × ECONOMICS</span>
-    <h1>ゲームで、経済はもっと身近になる。</h1>
-    <p>「げーけい部！」は、ゲームの世界観や仕組みから経済の考え方を学べるWEBメディアです。初心者でも“なんとなく”から一歩先へ進めるよう、やさしく解説します。</p>
-    <div class="cta">
-      <a class="btn" href="./projects.html">記事・プロジェクトを見る</a>
+<main>
+  <section class="hero neon-hero reveal">
+    <div class="hero-inner container">
+      <span class="badge">GAME × ECONOMICS</span>
+      <h1 class="catch">ネオンの街で、経済をゲームのように学ぶ。</h1>
+      <p class="sub">難しそうな理論も、光るインターフェースで体感的に理解しよう。</p>
+      <div class="cta">
+        <a class="btn" href="#latest">最新記事</a>
+        <a class="btn" href="#courses">学ぶコース</a>
+        <a class="btn" href="#labs">遊ぶ（実験）</a>
+      </div>
     </div>
   </section>
 
-<section class="card reveal" style="margin-top:20px">
-    <h2>最新トピック</h2>
-    <p>最新の記事やお知らせを3つほど掲載する予定です。</p>
+  <section class="topics card reveal container" id="latest" style="margin-top:32px">
+    <h2>トピックで探す</h2>
+    <div class="chip-group">
+      <button class="chip active" data-topic="all">すべて</button>
+      <button class="chip" data-topic="game">ゲーム理論</button>
+      <button class="chip" data-topic="micro">ミクロ</button>
+      <button class="chip" data-topic="macro">マクロ</button>
+      <button class="chip" data-topic="industry">産業事例</button>
+      <button class="chip" data-topic="esports">eスポーツ経済</button>
+    </div>
+    <div class="grid article-list" style="margin-top:24px">
+      <article class="article-card" data-topic="game micro">
+        <div class="thumb"></div>
+        <div class="title">囚人のジレンマを実際のゲームで体験</div>
+        <div class="meta">5分・初級</div>
+        <span class="tag">ゲーム理論</span>
+      </article>
+      <article class="article-card" data-topic="macro industry">
+        <div class="thumb"></div>
+        <div class="title">ゲーム市場から見る景気循環</div>
+        <div class="meta">8分・中級</div>
+        <span class="tag">マクロ</span>
+      </article>
+      <article class="article-card" data-topic="esports micro">
+        <div class="thumb"></div>
+        <div class="title">eスポーツチームの収益構造</div>
+        <div class="meta">6分・初級</div>
+        <span class="tag">eスポーツ経済</span>
+      </article>
+    </div>
+  </section>
+
+  <section class="picks container reveal" id="picks" style="margin-top:40px">
+    <h2>編集部ピック</h2>
+    <div class="pick-grid">
+      <article class="pick-card large">
+        <h3>経済の基礎をネオン街で駆け抜ける</h3>
+        <p class="meta">所要時間:10分 / 難易度:中級</p>
+        <div class="tags"><span class="tag">ミクロ</span> <span class="tag">ゲーム理論</span></div>
+        <div class="progress"><span style="width:60%"></span></div>
+      </article>
+      <article class="pick-card medium">
+        <h3>アイテム経済から学ぶ需給バランス</h3>
+        <p class="meta">所要時間:4分 / 難易度:初級</p>
+        <div class="tags"><span class="tag">産業事例</span></div>
+        <div class="progress"><span style="width:30%"></span></div>
+      </article>
+      <article class="pick-card medium">
+        <h3>プロゲーマーの年収と期待値</h3>
+        <p class="meta">所要時間:7分 / 難易度:上級</p>
+        <div class="tags"><span class="tag">eスポーツ経済</span></div>
+        <div class="progress"><span style="width:80%"></span></div>
+      </article>
+    </div>
   </section>
 </main>
 

--- a/script.js
+++ b/script.js
@@ -1,4 +1,6 @@
-document.getElementById('year').textContent = new Date().getFullYear();
+const yearEl = document.getElementById('year');
+if (yearEl) yearEl.textContent = new Date().getFullYear();
+
 // スクロールで .reveal 要素に .is-visible を付与
 (() => {
   const targets = document.querySelectorAll('.reveal');
@@ -21,3 +23,27 @@ document.getElementById('year').textContent = new Date().getFullYear();
 
   targets.forEach(el => io.observe(el));
 })();
+
+// ヒーローのパララックス
+const hero = document.querySelector('.neon-hero');
+if (hero) {
+  window.addEventListener('scroll', () => {
+    const offset = window.scrollY * 0.3;
+    hero.style.backgroundPosition = `center calc(50% + ${offset}px)`;
+  });
+}
+
+// トピックフィルタ
+const chips = document.querySelectorAll('.chip-group .chip');
+const articles = document.querySelectorAll('.article-list .article-card');
+chips.forEach(chip => {
+  chip.addEventListener('click', () => {
+    chips.forEach(c => c.classList.remove('active'));
+    chip.classList.add('active');
+    const topic = chip.dataset.topic;
+    articles.forEach(a => {
+      const topics = a.dataset.topic.split(' ');
+      a.style.display = topic === 'all' || topics.includes(topic) ? '' : 'none';
+    });
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -27,6 +27,28 @@ a:hover{color:#0D0F1A;background:var(--neon-magenta);box-shadow:0 0 12px var(--n
 .tag{display:inline-block;border:1px solid var(--neon-cyan);border-radius:999px;padding:2px 8px;font-size:12px}
 .thumb{height:120px;border-radius:12px;margin-bottom:12px;
   background:linear-gradient(135deg, rgba(255,46,255,.35), rgba(0,229,255,.25));}
+/* === ネオンヒーロー === */
+.neon-hero{position:relative;background:url('https://images.unsplash.com/photo-1497493292307-31c376b6e479?auto=format&fit=crop&w=1500&q=80') center / cover fixed;}
+.neon-hero::before{content:"";position:absolute;inset:0;background:rgba(13,15,26,.6);}
+.neon-hero .hero-inner{position:relative;padding:80px 0 120px;text-align:center;}
+.neon-hero .catch{font-size:40px;color:var(--neon-magenta);text-shadow:0 0 16px rgba(255,46,255,.8)}
+.neon-hero .sub{max-width:780px;margin:0 auto;opacity:.9}
+.neon-hero .cta{margin-top:24px;display:flex;gap:12px;justify-content:center;flex-wrap:wrap}
+
+/* === トピックチップ === */
+.chip-group{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+.chip{padding:6px 12px;border:1px solid var(--neon-cyan);border-radius:999px;background:transparent;color:var(--neon-cyan);cursor:pointer;font-size:14px}
+.chip:hover{box-shadow:0 0 8px var(--neon-cyan)}
+.chip.active{background:var(--neon-cyan);color:var(--night-slate)}
+
+/* === おすすめカード === */
+.pick-grid{display:grid;grid-template-columns:2fr 1fr;grid-auto-rows:1fr;gap:20px}
+.pick-card{background:#151926;border-radius:var(--radius);padding:24px;border:1px solid rgba(255,255,255,.06);box-shadow:0 8px 24px rgba(0,0,0,.45)}
+.pick-card.large{grid-row:span 2}
+.pick-card h3{margin-top:0;font-family:"Orbitron","Noto Sans JP",sans-serif;font-size:20px;color:var(--neon-magenta);text-shadow:0 0 8px rgba(255,46,255,.7)}
+.pick-card .tags{margin-top:8px}
+.progress{height:6px;background:#222;border-radius:3px;overflow:hidden;margin-top:12px}
+.progress span{display:block;height:100%;background:linear-gradient(90deg,var(--neon-magenta),var(--neon-cyan));box-shadow:0 0 6px var(--neon-magenta)}
 /* === Motion tokens (共通の速さ/イージング) === */
 :root{ --ease-out: cubic-bezier(.22,.61,.36,1); --dur-quick:.28s; --dur-slow:.6s; }
 


### PR DESCRIPTION
## Summary
- implement neon-hero section with parallax and multiple CTAs
- add topic chips for quick filtering and editor picks layout
- wire up parallax scroll and topic filtering in JS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dedb44f208333831bae494b303aea