### PR TITLE
Add interactive playground and diagram teaser

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,40 @@
     </div>
   </section>
 
+  <section id="labs" class="container reveal" style="margin-top:32px">
+    <h2>学べる遊び場</h2>
+    <div class="grid" style="margin-top:16px">
+      <div class="card playground">
+        <h3>需要と供給を動かす</h3>
+        <p>スライダーで価格と数量を変えて売上を体験。<a href="projects.html">続きは記事で</a></p>
+        <div class="sliders">
+          <label>価格<input type="range" id="price" min="0" max="100" value="50"></label>
+          <label>数量<input type="range" id="quantity" min="0" max="100" value="50"></label>
+        </div>
+        <svg id="sd-chart" viewBox="0 0 200 200">
+          <line x1="0" y1="200" x2="200" y2="0" stroke="var(--neon-magenta)" stroke-width="2"/>
+          <line x1="0" y1="0" x2="200" y2="200" stroke="var(--neon-cyan)" stroke-width="2"/>
+          <circle id="eqPoint" cx="100" cy="100" r="5" fill="#fff"/>
+        </svg>
+        <div id="revenue">売上: ¥2500</div>
+      </div>
+      <a class="card diagram-teaser" href="projects.html">
+        <h3>今週の1分図解</h3>
+        <svg viewBox="0 0 300 160" class="diagram">
+          <polyline points="20,120 80,80 140,100 200,60 260,70" fill="none" stroke="var(--neon-cyan)" stroke-width="3" stroke-linejoin="round"/>
+          <g fill="var(--neon-magenta)">
+            <circle cx="20" cy="120" r="5"/>
+            <circle cx="80" cy="80" r="5"/>
+            <circle cx="140" cy="100" r="5"/>
+            <circle cx="200" cy="60" r="5"/>
+            <circle cx="260" cy="70" r="5"/>
+          </g>
+        </svg>
+        <p>クリックで記事へ</p>
+      </a>
+    </div>
+  </section>
+
 
 
   <section class="topics card reveal container" id="latest" style="margin-top:32px">

--- a/script.js
+++ b/script.js
@@ -60,3 +60,23 @@ if(exitModal){
     exitModal.classList.remove('show');
   });
 }
+
+// ミニ実験：価格と数量で売上を表示
+const priceInput = document.getElementById('price');
+const qtyInput = document.getElementById('quantity');
+const revenue = document.getElementById('revenue');
+const eqPoint = document.getElementById('eqPoint');
+function updateLab(){
+  const price = Number(priceInput.value);
+  const qty = Number(qtyInput.value);
+  revenue.textContent = `売上: ¥${price * qty}`;
+  const x = (qty / 100) * 200;
+  const y = 200 - (price / 100) * 200;
+  eqPoint.setAttribute('cx', x);
+  eqPoint.setAttribute('cy', y);
+}
+if(priceInput && qtyInput && eqPoint){
+  priceInput.addEventListener('input', updateLab);
+  qtyInput.addEventListener('input', updateLab);
+  updateLab();
+}

--- a/styles.css
+++ b/styles.css
@@ -116,6 +116,15 @@ a:hover{color:#0D0F1A;background:var(--neon-magenta);box-shadow:0 0 12px var(--n
 /* Social proof */
 .proof-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:8px}
 
+/* Playground mini experiment */
+.playground .sliders{display:flex;flex-direction:column;gap:8px;margin:12px 0}
+.playground label{display:flex;gap:8px;align-items:center}
+.playground svg{margin-top:12px;background:#0D0F1A;border:1px solid rgba(255,255,255,.1);border-radius:8px;width:100%;max-width:240px;height:200px}
+
+/* Diagram teaser */
+.diagram-teaser{text-align:center;display:flex;flex-direction:column;align-items:center;justify-content:center}
+.diagram-teaser svg{margin:12px 0}
+
 /* Modal */
 .modal{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;align-items:center;justify-content:center;padding:24px;z-index:100}
 .modal.show{display:flex}


### PR DESCRIPTION
## Summary
- add "学べる遊び場" mini experiment with sliders to explore demand/supply and revenue
- include weekly diagram teaser linking to article
- style and script for interactive chart

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ee3a69a108333a940f22c596d71ba